### PR TITLE
Fixed example query in digitalocean_droplet table. Fixes #42

### DIFF
--- a/docs/tables/digitalocean_droplet.md
+++ b/docs/tables/digitalocean_droplet.md
@@ -71,11 +71,11 @@ from
 select
   name,
   region_slug,
-  size_gigabytes
+  memory
 from
   digitalocean_droplet
 order by
-  size_gigabytes desc
+  memory desc
 limit
   10;
 ```

--- a/docs/tables/digitalocean_droplet.md
+++ b/docs/tables/digitalocean_droplet.md
@@ -30,7 +30,7 @@ where
 select
   region_slug,
   count(id),
-  sum(size_gigabytes) as size_gigabytes
+  sum(memory) as total_memory
 from
   digitalocean_droplet
 group by


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  region_slug,
  count(id),
  sum(memory) as total_memory
from
  digitalocean_droplet
group by
  region_slug
order by
  region_slug;
+-------------+-------+--------------+
| region_slug | count | total_memory |
+-------------+-------+--------------+
| sfo3        | 1     | 1024         |
+-------------+-------+--------------+
```
</details>
