### PR TITLE
use string type for amount, add example amounts by year

### DIFF
--- a/digitalocean/table_digitalocean_bill.go
+++ b/digitalocean/table_digitalocean_bill.go
@@ -20,7 +20,7 @@ func tableDigitalOceanBill(ctx context.Context) *plugin.Table {
 			// Top columns
 			{Name: "date", Type: proto.ColumnType_TIMESTAMP, Description: "Time the billing history entry occured."},
 			// Other columns
-			{Name: "amount", Type: proto.ColumnType_DOUBLE, Description: "Amount of the billing history entry."},
+			{Name: "amount", Type: proto.ColumnType_STRING, Description: "Amount of the billing history entry."},
 			{Name: "description", Type: proto.ColumnType_STRING, Description: "Description of the billing history entry."},
 			{Name: "invoice_id", Type: proto.ColumnType_STRING, Description: "ID of the invoice associated with the billing history entry, if applicable."},
 			{Name: "invoice_uuid", Type: proto.ColumnType_STRING, Description: "UUID of the invoice associated with the billing history entry, if applicable."},

--- a/docs/tables/digitalocean_bill.md
+++ b/docs/tables/digitalocean_bill.md
@@ -14,3 +14,18 @@ select
 from
   digitalocean_bill;
 ```
+
+### Amounts by year
+
+```
+select
+  extract(year from date) as year,
+  sum(- to_number(amount,'L9G999g999.99')) as payment
+from
+  digitalocean.digitalocean_bill
+where 
+  type = 'Payment'
+group by
+  year
+```
+

--- a/docs/tables/digitalocean_bill.md
+++ b/docs/tables/digitalocean_bill.md
@@ -22,10 +22,10 @@ select
   extract(year from date) as year,
   sum(- to_number(amount,'L9G999g999.99')) as payment
 from
-  digitalocean.digitalocean_bill
-where 
+  digitalocean_bill
+where
   type = 'Payment'
 group by
-  year
+  year;
 ```
 


### PR DESCRIPTION
@cody: perfect example of the checklist item "money represented as string, not double" 