### PR TITLE
Fix get call for table digitalocean_snapshot

### DIFF
--- a/digitalocean/table_digitalocean_snapshot.go
+++ b/digitalocean/table_digitalocean_snapshot.go
@@ -92,7 +92,7 @@ func getSnapshot(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		plugin.Logger(ctx).Error("digitalocean_snapshot.getSnapshot", "query_error", err, "quals", quals, "resp", resp)
 		return nil, err
 	}
-	return result, nil
+	return *result, nil
 }
 
 func snapshotToURN(_ context.Context, d *transform.TransformData) (interface{}, error) {


### PR DESCRIPTION
# Issue

Getting error on doing a get call to table `digitalocean_snapshot`: 

```sql
> select title, regions, id, akas from digitalocean_snapshot where id = '125517051'

ERROR: rpc error: code = Unknown desc = failed to populate column 'akas': rpc error: code = Internal desc = transform snapshotToURN failed with panic interface conversion: interface {} is *godo.Snapshot, not godo.Snapshot (SQLSTATE HV000)
```

# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select title, regions, id, akas from digitalocean_snapshot where id = '125517051'
+------------------------------------+----------+-----------+---------------------------+
| title                              | regions  | id        | akas                      |
+------------------------------------+----------+-----------+---------------------------+
| droplete-2-delete-mr-1674538639216 | ["blr1"] | 125517051 | ["do:snapshot:125517051"] |
+------------------------------------+----------+-----------+---------------------------+
> select title, regions, id, akas from digitalocean_snapshot
+-------------------------------------+----------+--------------------------------------+------------------------------------------------------+
| title                               | regions  | id                                   | akas                                                 |
+-------------------------------------+----------+--------------------------------------+------------------------------------------------------+
| delete-volume-blr1-01-1674538782757 | ["blr1"] | 826c55b0-9ba9-11ed-9139-0a58ac14b5e0 | ["do:snapshot:826c55b0-9ba9-11ed-9139-0a58ac14b5e0"] |
| droplete-2-delete-mr-1674538639216  | ["blr1"] | 125517051                            | ["do:snapshot:125517051"]                            |
+-------------------------------------+----------+--------------------------------------+------------------------------------------------------+
```
</details>
