### PR TITLE
Add table digitalocean_container_registry closes #68

### DIFF
--- a/digitalocean/plugin.go
+++ b/digitalocean/plugin.go
@@ -22,6 +22,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"digitalocean_app":                tableDigitalOceanApp(ctx),
 			"digitalocean_balance":            tableDigitalOceanBalance(ctx),
 			"digitalocean_bill":               tableDigitalOceanBill(ctx),
+			"digitalocean_container_registry": tableDigitalOceanContainerRegistry(ctx),
 			"digitalocean_database":           tableDigitalOceanDatabase(ctx),
 			"digitalocean_domain":             tableDigitalOceanDomain(ctx),
 			"digitalocean_droplet":            tableDigitalOceanDroplet(ctx),

--- a/digitalocean/table_digitalocean_container_registry.go
+++ b/digitalocean/table_digitalocean_container_registry.go
@@ -34,13 +34,13 @@ func tableDigitalOceanContainerRegistry(ctx context.Context) *plugin.Table {
 				Name:        "storage_usage_bytes",
 				Type:        proto.ColumnType_INT,
 				Description: "The amount of storage used in the registry in bytes.",
-				Transform: transform.FromField("StorageUsageBytes"),
+				Transform:   transform.FromField("StorageUsageBytes"),
 			},
 			{
 				Name:        "storage_usage_bytes_updated_at",
 				Type:        proto.ColumnType_TIMESTAMP,
 				Description: "The time at which the storage usage was updated. Storage usage is calculated asynchronously, and may not immediately reflect pushes to the registry.",
-				Transform: transform.FromField("StorageUsageBytesUpdatedAt"),
+				Transform:   transform.FromField("StorageUsageBytesUpdatedAt"),
 			},
 			{
 				Name:        "urn",

--- a/digitalocean/table_digitalocean_container_registry.go
+++ b/digitalocean/table_digitalocean_container_registry.go
@@ -1,0 +1,93 @@
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/digitalocean/godo"
+
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableDigitalOceanContainerRegistry(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "digitalocean_container_registry",
+		Description: "DigitalOcean Container Registry",
+		List: &plugin.ListConfig{
+			Hydrate: getContainerRegistry,
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Type:        proto.ColumnType_STRING,
+				Description: "A globally unique name for the container registry.",
+			},
+			{
+				Name:        "created_at",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "A time value given in ISO8601 combined date and time format that represents when the registry was created.",
+			},
+			{
+				Name:        "storage_usage_bytes",
+				Type:        proto.ColumnType_INT,
+				Description: "The amount of storage used in the registry in bytes.",
+				Transform: transform.FromField("StorageUsageBytes"),
+			},
+			{
+				Name:        "storage_usage_bytes_updated_at",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The time at which the storage usage was updated. Storage usage is calculated asynchronously, and may not immediately reflect pushes to the registry.",
+				Transform: transform.FromField("StorageUsageBytesUpdatedAt"),
+			},
+			{
+				Name:        "urn",
+				Type:        proto.ColumnType_STRING,
+				Description: "The uniform resource name (URN) for the container registry.",
+				Transform:   transform.FromValue().Transform(registryToURN),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Type:        proto.ColumnType_STRING,
+				Description: resourceInterfaceDescription("title"),
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "akas",
+				Type:        proto.ColumnType_JSON,
+				Description: resourceInterfaceDescription("akas"),
+				Transform:   transform.FromValue().Transform(registryToURN).Transform(ensureStringArray),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func getContainerRegistry(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	conn, err := connect(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("digitalocean_container_registry.listContainerRegistries", "connection_error", err)
+		return nil, err
+	}
+
+	registry, _, err := conn.Registry.Get(ctx)
+	if err != nil {
+		plugin.Logger(ctx).Error("digitalocean_container_registry.listContainerRegistries", "api_error", err)
+		return nil, err
+	}
+	d.StreamListItem(ctx, registry)
+
+	return nil, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func registryToURN(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	registry := d.HydrateItem.(*godo.Registry)
+	return "do:registry:" + registry.Name, nil
+}

--- a/docs/tables/digitalocean_container_registry.md
+++ b/docs/tables/digitalocean_container_registry.md
@@ -1,0 +1,31 @@
+# Table: digitalocean_container_registry
+
+The DigitalOcean Container Registry (DOCR) is a private Docker image registry with additional tooling support that enables integration with your Docker environment and DigitalOcean Kubernetes clusters. DOCR registries are private and co-located in the datacenters where DigitalOcean Kubernetes clusters are operated for secure, stable, and performant rollout of images to your clusters.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  urn,
+  created_at
+from
+  digitalocean_container_registry;
+```
+
+### Get container registry details created in last 30 days
+
+```sql
+select
+  name,
+  urn,
+  created_at,
+  storage_usage_bytes_updated_at,
+  storage_usage_bytes
+from
+  digitalocean_container_registry
+where
+  created_at >= now() - interval '30' day;
+```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from digitalocean_container_registry
+------------+---------------------+---------------------------+--------------------------------+------------------------+------------+----------------------------+------------------------------------+
| name       | storage_usage_bytes | created_at                | storage_usage_bytes_updated_at | urn                    | title      | akas                       | _ctx                               |
+------------+---------------------+---------------------------+--------------------------------+------------------------+------------+----------------------------+------------------------------------+
| testreg123 | 0                   | 2023-01-24T17:21:23+05:30 | 0001-01-01T05:53:28+05:53      | do:registry:testreg123 | testreg123 | ["do:registry:testreg123"] | {"connection_name":"digitalocean"} |
+------------+---------------------+---------------------------+--------------------------------+------------------------+------------+----------------------------+------------------------------------+

Time: 1722.7ms. Rows fetched: 1. Hydrate calls: 0.
> select
  name,
  urn,
  created_at,
  storage_usage_bytes_updated_at,
  storage_usage_bytes
from
  digitalocean_container_registry
where
  created_at >= now() - interval '30' day;
+------------+------------------------+---------------------------+--------------------------------+---------------------+
| name       | urn                    | created_at                | storage_usage_bytes_updated_at | storage_usage_bytes |
+------------+------------------------+---------------------------+--------------------------------+---------------------+
| testreg123 | do:registry:testreg123 | 2023-01-24T17:21:23+05:30 | 0001-01-01T05:53:28+05:53      | 0                   |
+------------+------------------------+---------------------------+--------------------------------+---------------------+
```
</details>
